### PR TITLE
feat: introduce i18next with English and Polish translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "react-error-boundary": "^6.0.0",
     "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.16.0",
-    "react-spinners": "^0.17.0"
+    "react-spinners": "^0.17.0",
+    "i18next": "^23.11.5",
+    "react-i18next": "^15.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,20 @@
+import i18n from "i18next"
+import { initReactI18next } from "react-i18next"
+import enTranslation from "./locales/en/translation.json"
+import plTranslation from "./locales/pl/translation.json"
+
+void i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: enTranslation },
+      pl: { translation: plTranslation },
+    },
+    lng: "en",
+    fallbackLng: "en",
+    interpolation: {
+      escapeValue: false,
+    },
+  })
+
+export default i18n

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,9 @@
+{
+  "login": {
+    "usernamePlaceholder": "Provide username",
+    "passwordPlaceholder": "Provide password",
+    "signIn": "Sign in",
+    "fillBothFields": "Please fill in both fields",
+    "loginFailed": "Login failed"
+  }
+}

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -1,0 +1,9 @@
+{
+  "login": {
+    "usernamePlaceholder": "Podaj nazwę użytkownika",
+    "passwordPlaceholder": "Podaj hasło",
+    "signIn": "Zaloguj się",
+    "fillBothFields": "Proszę wypełnić oba pola",
+    "loginFailed": "Logowanie nie powiodło się"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client"
 import App from "./App.tsx"
 import "./index.css"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import "./i18n"
 
 const queryClient = new QueryClient()
 

--- a/src/shared/MultiSelect.tsx
+++ b/src/shared/MultiSelect.tsx
@@ -33,7 +33,12 @@ export default function MultiSelect<T extends { name: string }>(props: {
         preventApplicationClick: false,
       })
     }
-  }, [isDropdownVisible])
+  }, [
+    isDropdownVisible,
+    clickHook?.applicationClick,
+    clickHook?.preventApplicationClick,
+    setApplicationClick,
+  ])
 
   useEffect(() => {
     if (clickHook?.applicationClick === true && isDropdownVisible) {
@@ -43,7 +48,7 @@ export default function MultiSelect<T extends { name: string }>(props: {
         preventApplicationClick: true,
       })
     }
-  }, [clickHook?.applicationClick])
+  }, [clickHook?.applicationClick, isDropdownVisible, setApplicationClick])
 
   function getFilteredItems() {
     const selectedItemsNames = props.selectedItems().map((item) => item.name)

--- a/src/shared/ValidatedTextInput.tsx
+++ b/src/shared/ValidatedTextInput.tsx
@@ -37,7 +37,7 @@ export default function ValidatedTextInput({
     } else {
       setValid(true)
     }
-  }, [getInputValue])
+  }, [getInputValue, minLength, maxLength, setValid])
 
   return (
     <div className={`w-${inputWidth || 48}`}>

--- a/src/sites/header/UserTooltip.tsx
+++ b/src/sites/header/UserTooltip.tsx
@@ -28,7 +28,7 @@ export default function UserTooltip() {
         preventApplicationClick: true,
       })
     }
-  }, [clickHook.applicationClick])
+  }, [clickHook.applicationClick, isExpanded, setApplicationClick])
 
   function toggleTooltip(): void {
     if (!isExpanded) {

--- a/src/sites/login/Login.tsx
+++ b/src/sites/login/Login.tsx
@@ -10,6 +10,7 @@ import { fetchUserByLoginData } from "../../api/requests"
 import toast from "react-hot-toast"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faRightToBracket } from "@fortawesome/free-solid-svg-icons"
+import { useTranslation } from "react-i18next"
 
 export interface LoginUser {
   username: string
@@ -18,6 +19,7 @@ export interface LoginUser {
 
 export default function Login() {
   const { authData, setAuth } = useAuth()
+  const { t } = useTranslation()
   const login = useMutation({
     mutationFn: (loginUser: LoginUser) => {
       return fetchUserByLoginData(loginUser)
@@ -31,11 +33,11 @@ export default function Login() {
   useEffect(() => {
     if (login.isError) {
       toast.error(
-        login.error instanceof Error ? login.error.message : "Login failed",
+        login.error instanceof Error ? login.error.message : t("login.loginFailed"),
         { position: "bottom-center" },
       )
     }
-  }, [login.isError])
+  }, [login.isError, login.error, t])
 
   if (authData.isAuthenticated) {
     return <Navigate to={"/edit"} replace={true} />
@@ -59,7 +61,7 @@ export default function Login() {
       if (!isDisabled()) {
         login.mutate(loginUser)
       } else {
-        toast.error("Please fill in both fields", { position: "bottom-center" })
+        toast.error(t("login.fillBothFields"), { position: "bottom-center" })
       }
     }
   }
@@ -80,7 +82,7 @@ export default function Login() {
         <TextInput
           setInputValue={(username) => setLoginUser({ ...loginUser, username })}
           getInputValue={() => loginUser.username}
-          placeholder={`Provide username`}
+          placeholder={t("login.usernamePlaceholder")}
           isPassword={false}
         />
       </div>
@@ -88,7 +90,7 @@ export default function Login() {
         <TextInput
           setInputValue={(password) => setLoginUser({ ...loginUser, password })}
           getInputValue={() => loginUser.password}
-          placeholder={`Provide password`}
+          placeholder={t("login.passwordPlaceholder")}
           isPassword={true}
         />
       </div>
@@ -100,7 +102,7 @@ export default function Login() {
             icon={<FontAwesomeIcon icon={faRightToBracket} />}
             disabled={isDisabled()}
             onClick={() => login.mutate(loginUser)}
-            text={`Sign in`}
+            text={t("login.signIn")}
           />
         )}
       </div>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,6 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- add i18next configuration with English and Polish translation files
- wire i18next into the app and translate the login page
- fix React hook dependency warnings to satisfy lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689665ccb05c83238555658f38859256